### PR TITLE
Support new image-builder behavior in snow-uc docker images

### DIFF
--- a/use-cases/snow-uc/build-images/components/daily-median-aggregator/Dockerfile
+++ b/use-cases/snow-uc/build-images/components/daily-median-aggregator/Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Get Daily Median Aggregator
-# clone https://gitlab.com/wds-co/SnowWatch-SODALITE.git to build context before building
-COPY SnowWatch-SODALITE/DailyMedianAggregator/ SnowWatch-SODALITE/DailyMedianAggregator/
-COPY SnowWatch-SODALITE/config.json SnowWatch-SODALITE/config.json
+# clone https://gitlab.com/wds-co/SnowWatch-SODALITE.git and copy this file in SnowWatch-SODALITE dir
+COPY DailyMedianAggregator/ SnowWatch-SODALITE/DailyMedianAggregator/
+COPY config.json SnowWatch-SODALITE/config.json
 
 WORKDIR SnowWatch-SODALITE/DailyMedianAggregator/
 

--- a/use-cases/snow-uc/build-images/components/weather-condition-filter/Dockerfile
+++ b/use-cases/snow-uc/build-images/components/weather-condition-filter/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Get Weather Condition Filter
-# clone https://gitlab.com/wds-co/SnowWatch-SODALITE.git to build context before building
-COPY SnowWatch-SODALITE/WeatherConditionFilter/ SnowWatch-SODALITE/WeatherConditionFilter/
-COPY SnowWatch-SODALITE/data/masks/ SnowWatch-SODALITE/data/masks/
-COPY SnowWatch-SODALITE/config.json SnowWatch-SODALITE/config.json
+# clone https://gitlab.com/wds-co/SnowWatch-SODALITE.git and copy this file in SnowWatch-SODALITE dir
+COPY WeatherConditionFilter/ SnowWatch-SODALITE/WeatherConditionFilter/
+COPY data/masks/ SnowWatch-SODALITE/data/masks/
+COPY config.json SnowWatch-SODALITE/config.json
 
 WORKDIR SnowWatch-SODALITE/WeatherConditionFilter/
 

--- a/use-cases/snow-uc/build-images/components/webcam-crawler/Dockerfile
+++ b/use-cases/snow-uc/build-images/components/webcam-crawler/Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Get Webcam Crawler
-# clone https://gitlab.com/wds-co/SnowWatch-SODALITE.git to build context before building
-COPY SnowWatch-SODALITE/WebCamCrawler/ SnowWatch-SODALITE/WebCamCrawler/
-COPY SnowWatch-SODALITE/config.json SnowWatch-SODALITE/config.json
+# clone https://gitlab.com/wds-co/SnowWatch-SODALITE.git and copy this file in SnowWatch-SODALITE dir
+COPY WebCamCrawler/ SnowWatch-SODALITE/WebCamCrawler/
+COPY config.json SnowWatch-SODALITE/config.json
 
 
 


### PR DESCRIPTION
This PR changes the relation between each Dockerfile and its respective build-context and makes them compliant with the new image-builder format.

Dockerfiles are usually expected to be running within the source tree, as they rely on
relative file paths for e.g. COPY operations. Therefore it is more natural, to follow this philosophy in snow-uc images.

BEFORE

workdir
| -- Dockerfile
| -- SnowWatch-SODALITE 
|    | -- dir1
|    | -- dir2 
|    | -- file1
....

NOW

workdir
| -- SnowWatch-SODALITE 
|    | -- Dockerfile
|    | -- dir1
|    | -- dir2 
|    | -- file1
...