### PR TITLE
Vehicleiot images now deploy with node-exporter running

### DIFF
--- a/use-cases/vehicleiot-uc/full-demo/input.yaml
+++ b/use-cases/vehicleiot-uc/full-demo/input.yaml
@@ -1,7 +1,7 @@
 ssh-key-name: alexander_maslennikov
-image-name: "centos-7 x86_64"
+image-name: "centos-node_exporter"
 openstack-network-name: xlab
-security-groups: default,remote_access,vehicle-iot-full
+security-groups: default,remote_access,vehicle-iot-full,node-exporter
 flavor-name: m1.medium
 docker-network: knowgo_net
 dockerhub-user: 

--- a/use-cases/vehicleiot-uc/full-demo/service.yaml
+++ b/use-cases/vehicleiot-uc/full-demo/service.yaml
@@ -114,6 +114,9 @@ topology_template:
         security_groups:  { get_input: security-groups } 
         flavor:           { get_input: flavor-name }
         username: centos
+        meta:
+          prometheus_io_scrape: true
+          prometheus_io_port: 9100
       requirements:  
        - protected_by:  security-rules-vehicle-iot-full
 


### PR DESCRIPTION
Indika will test the correct functioning of these changes this afternoon, but they should simply work