### PR TITLE
Add ALDE TOSCA implementation to configure ALDE with new applications

### DIFF
--- a/hpc/alde-cloud-test/input.yaml
+++ b/hpc/alde-cloud-test/input.yaml
@@ -1,0 +1,4 @@
+alde_host: http://77.231.202.137:5000
+app_name: tosca-test
+pbs_path: jobs/test.pbs
+testbed_id: "1"

--- a/hpc/alde-cloud-test/input.yaml
+++ b/hpc/alde-cloud-test/input.yaml
@@ -1,4 +1,4 @@
-alde_host: http://77.231.202.137:5000
+alde_host: http://192.168.2.20:5000
 app_name: tosca-test
 pbs_path: jobs/test.pbs
 testbed_id: "1"

--- a/hpc/alde-cloud-test/playbooks/create.yaml
+++ b/hpc/alde-cloud-test/playbooks/create.yaml
@@ -1,0 +1,90 @@
+---
+- hosts: all
+  become: no
+  gather_facts: no
+  tasks:
+# ===============================================================
+# Step1: Create Application
+# ===============================================================
+    - name: create application
+      uri:
+        method: POST
+        url: "{{alde_host}}/api/v1/applications"
+        body_format: json
+        body:
+          name: "{{app_name}}"
+        return_content: yes
+        status_code: 201
+      register: content
+    - name: parse application ID
+      set_fact:
+        application_id: "{{ content.json.id }}"
+
+# ===============================================================
+# Step2: Create Executable
+# ===============================================================
+    - name: create executable
+      uri:
+        method: POST
+        url: "{{alde_host}}/api/v1/executables"
+        body_format: json
+        body:
+          application_id: "{{application_id}}"
+          status: COMPILED
+          compilation_type: SINGULARITY_PM
+          executable_file: "{{pbs_path}}"
+        return_content: yes
+        status_code: 201
+      register: content
+    - name: parse executable ID
+      set_fact:
+        executable_id: "{{ content.json.id }}"
+
+# ===============================================================
+# Step3: Create Deployment
+# ===============================================================
+    - name: create deployment
+      uri:
+        method: POST
+        url: "{{alde_host}}/api/v1/deployments"
+        body_format: json
+        body:
+          executable_id: "{{executable_id}}"
+          testbed_id: "{{testbed_id}}"
+        return_content: yes
+        status_code: 201
+      register: content
+
+# ===============================================================
+# Step4: Create Execution Configuration
+# ===============================================================
+    - name: create execution configuration
+      uri:
+        method: POST
+        url: "{{alde_host}}/api/v1/execution_configurations"
+        body_format: json
+        body:
+          application_id: "{{application_id}}"
+          executable_id: "{{executable_id}}"
+          testbed_id: "{{testbed_id}}"
+          execution_type: TORQUE:QSUB
+        return_content: yes
+        status_code: 201
+      register: content
+    - name: parse configuration ID
+      set_fact:
+        configuration_id: "{{ content.json.id }}"
+
+# ===============================================================
+# Step5: Create Execution Configuration
+# ===============================================================
+    - name: launch execution configuration
+      uri:
+        method: PATCH
+        url: "{{alde_host}}/api/v1/execution_configurations/{{configuration_id}}"
+        body_format: json
+        body:
+          launch_execution: true
+        return_content: yes
+        status_code: 200
+      register: content

--- a/hpc/alde-cloud-test/service.yaml
+++ b/hpc/alde-cloud-test/service.yaml
@@ -1,0 +1,47 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  alde_api_type:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        inputs:
+          alde_host:
+            default: { get_input: alde_host }
+            type: string
+          app_name:
+            default: { get_input: app_name }
+            type: string
+          pbs_path:
+            default: { get_input: pbs_path }
+            type: string
+          testbed_id:
+            default: { get_input: testbed_id }
+            type: string
+
+        operations:
+          create: playbooks/create.yaml
+
+topology_template:
+  inputs:
+    alde_host:
+      type: string
+    app_name:
+      type: string
+    pbs_path:
+      type: string
+    testbed_id:
+      type: string
+
+
+  node_templates:
+    local-workstation:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: localhost
+        public_address: localhost
+
+    alde_api:
+      type: alde_api_type
+      requirements:
+        - host: local-workstation


### PR DESCRIPTION
Based on the comments of the previous pul requests:

- Alde server have been removed from public access
- Alde server is locally network accessible within the orchestrator project
- Input.yaml contains the default IP of the ALDE server: 192.168.2.20
- The **alde-cloud-test** blueprint implementation  is just a local ansible execution to setup the alde environment with a new application. The ansible scripts runs in the local opera node where it is executed and connects to the alde_host endpoint to launch the necessary HTTP requests. This is done this way because there are some initial configurations of the ALDE server that require to setup SSH connections to the HCP cluster were torque is accessible.




